### PR TITLE
feat: add GitHub repository link to header

### DIFF
--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -28,17 +28,20 @@ Transforms GitHub issues into detailed technical specifications by gathering req
 ## Workflow
 
 ### Phase 1: Issue Analysis
+
 1. **Fetch Issue** — Retrieve issue title, description, and labels
 2. **Identify Scope** — Determine feature type (UI, API, integration, etc.)
 3. **Extract Requirements** — Parse explicit and implicit requirements
 
 ### Phase 2: Requirements Clarification
+
 4. **Ask Questions** — Probe gaps and ambiguities in the spec
 5. **Propose Alternatives** — Present 2-3 architectural approaches for key decisions
 6. **User Selection** — Let user choose preferred approach (or customize)
 7. **Document Decisions** — Lock in chosen direction
 
 ### Phase 3: Specification Writing
+
 8. **Write Specs** — Generate elaborate technical specification covering:
    - **Overview** — What problem does this solve?
    - **Architecture** — System design and components involved
@@ -52,6 +55,7 @@ Transforms GitHub issues into detailed technical specifications by gathering req
    - **Future Considerations** — Scalability, maintainability, evolution paths
 
 ### Phase 4: Issue Comment
+
 9. **Post Specs** — Add finalized specification as GitHub issue comment
 10. **Link Back** — Reference issue in the comment for traceability
 
@@ -60,18 +64,21 @@ Transforms GitHub issues into detailed technical specifications by gathering req
 The skill will ask targeted questions based on issue type:
 
 ### For Feature Requests
+
 - **Scope**: Is this a new feature, enhancement, or refactor?
 - **Users**: Who benefits? What's the primary use case?
 - **Constraints**: Timeline, dependencies, breaking changes?
 - **Integration**: Does this touch other features? Need migrations?
 
 ### For Bug Fixes
+
 - **Reproduction**: Can you provide steps to reproduce?
 - **Root Cause**: Environment specific or affects all users?
 - **Regression Risk**: What existing functionality could be affected?
 - **Test Coverage**: Should we add tests to prevent recurrence?
 
 ### For Architecture/Infrastructure
+
 - **Scale**: Expected growth, performance targets?
 - **Availability**: Uptime requirements, graceful degradation?
 - **Security**: Authentication, authorization, data sensitivity?
@@ -106,29 +113,36 @@ User selects one, or provides custom hybrid approach.
 # Spec: [Issue Title]
 
 ## Overview
+
 [1-2 paragraphs explaining the problem and solution]
 
 ## Architecture
+
 [System design, components, interactions]
 
 ## Data Flow
+
 [How data moves through the system - include diagram if complex]
 
 ## Implementation Plan
+
 1. [First step]
 2. [Second step]
 3. ...
 
 ## Testing Strategy
+
 - Unit tests: [coverage areas]
 - Integration tests: [component interactions]
 - E2E tests: [user journeys]
 
 ## Edge Cases & Error Handling
+
 - [Case 1]: [How to handle]
 - [Case 2]: [How to handle]
 
 ## Future Considerations
+
 - [Scalability concern]
 - [Maintenance note]
 - [Evolution path]
@@ -151,12 +165,14 @@ Before posting to issue, verify:
 To prevent implementation failures, ensure specs include:
 
 ### 1. **State Management Complexity**
+
 - Specify how state flows between components and hooks
 - Include diagrams or ASCII art for complex state transitions
 - Call out where debouncing, throttling, or caching is needed
 - Explicitly document: "when is state updated?" and "how often?"
 
 **Example:**
+
 ```
 User types → useHeadingExtraction parses (debounce 300ms)
   → update Heading[] → useScrollTracking monitors scroll
@@ -164,12 +180,14 @@ User types → useHeadingExtraction parses (debounce 300ms)
 ```
 
 ### 2. **Third-Party Library Specifics**
+
 - When integrating external libraries (Monaco, remark, marked), include specific API calls
 - Note which APIs are hard to test in Jest (e.g., Monaco scroll events)
 - Mention test environment gaps and workarounds
 - Provide code snippets for complex integrations
 
 **Example:**
+
 ```typescript
 editor.revealLineInCenter(lineNumber, ScrollType.Smooth);
 editor.onDidScrollChange((e) => {
@@ -178,6 +196,7 @@ editor.onDidScrollChange((e) => {
 ```
 
 ### 3. **Precise Acceptance Criteria**
+
 - Replace vague terms with specific, testable behavior
 - **Bad:** "Scroll works"
 - **Good:** "Clicking TOC entry scrolls editor to heading, center heading in viewport, smooth animation"
@@ -185,12 +204,14 @@ editor.onDidScrollChange((e) => {
 - Specify error states ("if heading not found, show toast", "if editor is null, disable TOC")
 
 ### 4. **Critical Integration Points**
+
 - Call out where bugs are most likely (e.g., "scroll tracking is fragile because line numbers shift during edits")
 - Document data validation boundaries (e.g., "line number must be validated before scroll")
 - Mention race conditions or timing issues (e.g., "content changed while scrolling?")
 - Include failure recovery strategies
 
 **Example:**
+
 ```
 CRITICAL: When user types, heading extraction re-runs and line numbers change.
 If scroll tracking holds old line numbers, it will scroll to wrong location.
@@ -199,6 +220,7 @@ at scroll time using currentHeadingId.
 ```
 
 ### 5. **Hook/Component Wiring Diagram**
+
 - For complex UIs with multiple hooks, include explicit data flow
 - Show which component owns state vs. which hook transforms it
 - Clarify prop drilling and callback chains
@@ -219,12 +241,14 @@ TocTab
 ```
 
 ### 6. **Testing Gaps & Workarounds**
+
 - Identify what's hard to test in the chosen test framework
 - Suggest testing strategies for those parts (integration tests, manual testing, snapshot tests)
 - Note coverage limitations (e.g., "Monaco APIs hard to mock, expect 85% branch coverage for TocTab")
 - Provide mock implementations or test helpers
 
 **Example:**
+
 ```
 HARD TO TEST in Jest:
 - Monaco editor scroll events (requires real editor instance)
@@ -237,11 +261,13 @@ SOLUTION:
 ```
 
 ### 7. **Performance Constraints**
+
 - Specify where performance matters ("heading extraction must not block typing")
 - Call out when optimization is premature vs. critical ("regex is fast enough for <10k lines")
 - Mention thresholds ("if >500 headings, consider virtual scrolling")
 
 ### 8. **Explicit Error Handling**
+
 - Don't just list edge cases; specify behavior
 - **Bad:** "Handle empty documents"
 - **Good:** "If content has no headings, show message 'No headings found' in TOC. Do not crash."
@@ -260,60 +286,74 @@ SOLUTION:
 These gaps appeared in real specs and caused implementation rework. Watch for them:
 
 ### 1. **Scroll-to-Element Functionality (Fragile)**
+
 **What devs misunderstood:** Just mention the library API (e.g., "use Monaco's `revealLineInCenter()`")
 **What was missing:**
+
 - How to map TOC click → heading ID → current line number
 - That line numbers shift when content changes
 - How to handle "heading not found" errors
 - Debouncing requirements to avoid lag
 
 **Better spec includes:**
+
 - Algorithm: "On click, lookup heading by ID → find its current line number → scroll → re-validate"
 - Code snippet showing the pattern
 - Error handling: "If heading not found (deleted by user), show toast 'Heading no longer exists'"
 - "After each keystroke, heading extraction updates line numbers. Use ID-based lookups, not line numbers stored in state."
 
 ### 2. **Hook Composition Complexity**
+
 **What devs misunderstood:** Spec lists hooks but not how they interact
 **What was missing:**
+
 - Which hook owns state? Which transforms it?
 - Who calls whom? What are the props?
 - Example: useScrollTracking needs both editorRef AND the Heading[] array to work
 
 **Better spec includes:**
+
 - Wiring diagram showing component → hook → Monaco API flow
 - Clear prop/callback contracts for each hook
 - "useScrollTracking watches scroll changes on editorRef. When scroll happens, find which heading's line number matches visible range, update currentHeadingId. Re-run on: scroll change + Heading[] array change (because line numbers shifted)"
 
 ### 3. **Testing Challenges Hidden**
+
 **What devs misunderstood:** Spec says "100% test coverage" without noting library constraints
 **What was missing:**
+
 - Monaco APIs can't be fully mocked in Jest
 - Scroll tracking accuracy is hard to test without real editor
 - "Expected branch coverage 87.5%, not 100%, due to Jest limitations with Monaco"
 
 **Better spec includes:**
+
 - "Core logic (heading extraction) → test with 100% coverage"
 - "Hook behavior (useScrollTracking) → test with mocks at 85% coverage"
 - "Integration (click → scroll) → test manually or with E2E suite"
 - Suggests test file structure: core logic separate from Monaco integration
 
 ### 4. **Acceptance Criteria Too Vague**
+
 **What was accepted:** "Click-to-scroll works" ✓
 **What actually broke:** "Scroll works" but goes to wrong location, no smooth animation, no error recovery
 
 **Better spec replaces acceptance criteria like:**
+
 - ❌ "Scroll works"
 - ✓ "Clicking TOC entry scrolls editor: (1) center heading in viewport using `revealLineInCenter()`, (2) use smooth scroll animation, (3) if heading line not found, disable scroll silently and let user scroll manually"
 
 ### 5. **Real-Time Updates + Line Number Tracking**
+
 **What devs built:** Heading extraction on every keystroke ✓, but line numbers cached ✗
 **What was missing:**
+
 - "Every heading extraction MUST re-calculate line numbers from scratch. Do not cache them."
 - Race condition: "If useScrollTracking runs while Heading[] is updating, currentHeadingId may point to stale line number"
 - Solution: "Use heading ID as primary key. Look up line number at scroll time, not at extraction time"
 
 **Better spec includes:**
+
 - "Line numbers are not stable. Always compute them fresh during parsing."
 - "currentHeadingId (stored in state) is the source of truth, not line number"
 - "On scroll: lookup currentHeadingId in Heading[] array, get its current lineNumber, validate it exists"

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ These are not yet implemented:
 
 ## Spec-driven development (SDD) Flow
 
-1. **Create SDD** — Use `/architect <github-issue-url>` to generate a Software Design Document from the issue 
+1. **Create SDD** — Use `/architect <github-issue-url>` to generate a Software Design Document from the issue
 2. **Request Implementation** — Comment on the issue with `@claude implement`
 3. **Review & Refine** — Once the PR is created, review code quality, add comments as needed for refinements
 4. **Merge** — Merge the PR when satisfied with the implementation

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,7 +16,7 @@ const config: Config = {
   },
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   transformIgnorePatterns: [
-    "/node_modules/(?!(react-markdown|remark-gfm|github-markdown-css|@types/github-markdown-css|micromark|decode-named-character-reference|character-entities|unist-|mdast-util-|ccount|escape-string-regexp|markdown-table|space-separated-tokens|comma-separated-tokens|web-namespaces|vfile|bail|trough|is-buffer|is-plain-obj|is-reference)/)",
+    "/node_modules/(?!(react-markdown|remark-gfm|github-markdown-css|@types/github-markdown-css|micromark|decode-named-character-reference|character-entities|unist-|mdast-util-|ccount|escape-string-regexp|markdown-table|space-separated-tokens|comma-separated-tokens|web-namespaces|vfile|bail|trough|is-buffer|is-plain-obj|is-reference|react-icons)/)",
   ],
 
   // ── Coverage ────────────────────────────────────────────────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "next": "^15.3.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-icons": "^5.6.0",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1"
       },
@@ -10097,6 +10098,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next": "^15.3.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1"
   },

--- a/src/app/studio/page.test.tsx
+++ b/src/app/studio/page.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+
+// Mock the heavy components that use ESM modules
+jest.mock("@/components/EditorPane", () => ({
+  EditorPane: () => <div data-testid="editor-pane">Editor Pane</div>,
+}));
+
+jest.mock("@/components/ArticleList", () => ({
+  ArticleList: () => <div data-testid="article-list">Article List</div>,
+}));
+
+jest.mock("@/components/SidePanel", () => ({
+  SidePanel: () => <div data-testid="side-panel">Side Panel</div>,
+}));
+
+jest.mock("@/components/VersionStrip", () => ({
+  VersionStrip: () => <div data-testid="version-strip">Version Strip</div>,
+}));
+
+import StudioPage from "./page";
+
+describe("StudioPage", () => {
+  describe("GitHub Repository Link", () => {
+    it("should render GitHub icon link in header", () => {
+      render(<StudioPage />);
+      const githubLink = screen.getByRole("link", {
+        name: /visit inkwell github repository/i,
+      });
+      expect(githubLink).toBeInTheDocument();
+    });
+
+    it("should link to correct GitHub repository URL", () => {
+      render(<StudioPage />);
+      const githubLink = screen.getByRole("link", {
+        name: /visit inkwell github repository/i,
+      }) as HTMLAnchorElement;
+      expect(githubLink.href).toBe("https://github.com/linnienaryshkin/inkwell");
+    });
+
+    it("should open link in new tab", () => {
+      render(<StudioPage />);
+      const githubLink = screen.getByRole("link", {
+        name: /visit inkwell github repository/i,
+      });
+      expect(githubLink).toHaveAttribute("target", "_blank");
+    });
+
+    it("should have rel attribute for security", () => {
+      render(<StudioPage />);
+      const githubLink = screen.getByRole("link", {
+        name: /visit inkwell github repository/i,
+      });
+      expect(githubLink).toHaveAttribute("rel", "noopener noreferrer");
+    });
+
+    it("should have proper aria-label for accessibility", () => {
+      render(<StudioPage />);
+      const githubLink = screen.getByRole("link", {
+        name: /visit inkwell github repository/i,
+      });
+      expect(githubLink).toHaveAttribute("aria-label", "Visit Inkwell GitHub repository");
+    });
+
+    it("should have title attribute for tooltip", () => {
+      render(<StudioPage />);
+      const githubLink = screen.getByRole("link", {
+        name: /visit inkwell github repository/i,
+      });
+      expect(githubLink).toHaveAttribute("title", "Visit Inkwell GitHub repository");
+    });
+  });
+
+  describe("Header Layout", () => {
+    it("should render header with Inkwell title", () => {
+      render(<StudioPage />);
+      expect(screen.getByText("Inkwell")).toBeInTheDocument();
+    });
+
+    it("should render theme toggle button", () => {
+      render(<StudioPage />);
+      const themeButton = screen.getByRole("button", {
+        name: /☀ Light/,
+      });
+      expect(themeButton).toBeInTheDocument();
+    });
+
+    it("should render repository name", () => {
+      render(<StudioPage />);
+      expect(screen.getByText("my-writing-repo")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/studio/page.tsx
+++ b/src/app/studio/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { FaGithub } from "react-icons/fa";
 import { ArticleList } from "@/components/ArticleList";
 import { EditorPane } from "@/components/EditorPane";
 import { SidePanel } from "@/components/SidePanel";
@@ -175,6 +176,21 @@ export default function StudioPage() {
           </span>
         </div>
         <div className="flex items-center gap-3">
+          <a
+            href="https://github.com/linnienaryshkin/inkwell"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Visit Inkwell GitHub repository"
+            aria-label="Visit Inkwell GitHub repository"
+            className="inline-flex items-center justify-center p-1 transition-colors"
+            style={{
+              color: "var(--text-secondary)",
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.color = "var(--text-primary)")}
+            onMouseLeave={(e) => (e.currentTarget.style.color = "var(--text-secondary)")}
+          >
+            <FaGithub size={20} />
+          </a>
           <button
             onClick={() => setTheme((t) => (t === "dark" ? "light" : "dark"))}
             title={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}


### PR DESCRIPTION
Closes #67

Add a GitHub icon button to the studio header that directs users to the open-source repository.

## Changes
- Added GitHub icon link to header using FaGithub from react-icons
- Styled with dark theme using CSS variables
- Includes security attributes (target="_blank", rel="noopener noreferrer")
- Accessibility features (aria-label, title)
- Comprehensive test coverage with 9 tests
- All quality checks passing

Generated with [Claude Code](https://claude.ai/code)