### PR TITLE
Remove my-writing-repo label from header

### DIFF
--- a/src/app/studio/page.test.tsx
+++ b/src/app/studio/page.test.tsx
@@ -83,10 +83,5 @@ describe("StudioPage", () => {
       });
       expect(themeButton).toBeInTheDocument();
     });
-
-    it("should render repository name", () => {
-      render(<StudioPage />);
-      expect(screen.getByText("my-writing-repo")).toBeInTheDocument();
-    });
   });
 });

--- a/src/app/studio/page.tsx
+++ b/src/app/studio/page.tsx
@@ -207,12 +207,6 @@ export default function StudioPage() {
           >
             {theme === "dark" ? "☀ Light" : "☾ Dark"}
           </button>
-          <span
-            className="text-xs px-2 py-1 rounded"
-            style={{ background: "var(--bg-tertiary)", color: "var(--text-secondary)" }}
-          >
-            my-writing-repo
-          </span>
           <div
             className="w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium"
             style={{ background: "var(--accent)", color: "var(--bg-primary)" }}


### PR DESCRIPTION
Removes the redundant static badge from the header since the app is scoped to a single connected GitHub repository.

Closes #69

Generated with [Claude Code](https://claude.ai/code)