### PR TITLE
enhance: add spinner animation to MermaidBlock loading state (#76)

### DIFF
--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -38,3 +38,12 @@ body {
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
 }
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/ui/src/components/MermaidBlock.test.tsx
+++ b/ui/src/components/MermaidBlock.test.tsx
@@ -32,6 +32,19 @@ describe("MermaidBlock", () => {
 
       expect(screen.getByText("Rendering diagram…")).toBeInTheDocument();
     });
+
+    it("should show spinner with role status while render is pending", async () => {
+      mockMermaid.render.mockImplementation(
+        () =>
+          new Promise(() => {
+            // Never resolves to keep component in loading state
+          })
+      );
+
+      render(<MermaidBlock code="graph TD\n A[Start]" />);
+
+      expect(screen.getByRole("status", { name: "Rendering diagram" })).toBeInTheDocument();
+    });
   });
 
   describe("Success state", () => {

--- a/ui/src/components/MermaidBlock.tsx
+++ b/ui/src/components/MermaidBlock.tsx
@@ -50,7 +50,30 @@ export function MermaidBlock({ code }: Props) {
 
   if (!svg) {
     return (
-      <div style={{ color: "var(--text-secondary)", fontSize: "13px" }}>Rendering diagram…</div>
+      <div
+        role="status"
+        aria-label="Rendering diagram"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          color: "var(--text-secondary)",
+          fontSize: "13px",
+        }}
+      >
+        <div
+          style={{
+            width: "14px",
+            height: "14px",
+            borderRadius: "50%",
+            border: "2px solid var(--border)",
+            borderTopColor: "var(--accent)",
+            animation: "spin 0.8s linear infinite",
+            flexShrink: 0,
+          }}
+        />
+        Rendering diagram…
+      </div>
     );
   }
 


### PR DESCRIPTION
## Summary

- Adds a CSS `@keyframes spin` animation to `globals.css`
- Replaces the plain "Rendering diagram…" text with a spinning circle indicator + text, using `role="status"` and `aria-label` for accessibility
- Adds a new test asserting the spinner is present via `getByRole("status")`

## Test plan

- [x] All 172 tests pass with ≥90% branch coverage (MermaidBlock at 100%)
- [x] TypeScript, ESLint, Prettier all clean
- [x] No high/critical security vulnerabilities

Closes #76