### PR TITLE
#0: add dev and lint-ui Makefile targets, expand CORS allowlist

### DIFF
--- a/.claude/agents/git-agent.md
+++ b/.claude/agents/git-agent.md
@@ -41,7 +41,7 @@ Co-Authored-By: Claude Code <noreply@anthropic.com>
 ```
 
 ### 4. Create Branch (if needed)
-- **Format:** `#42/feature-[description]` or `#0/bug-[description]`
+- **Format:** `#42/feature-[description]`, `#0/bug-[description]`, or `#0/chore-[description]` (example: `#0/chore-makefile-cors-fixes`)
 - Only create if no branch exists for these changes
 
 ### 5. Push and Create PR (if needed)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: dev-ui dev-api test-ui test-api lint-api quality-gate-ui
+.PHONY: dev dev-ui dev-api test-ui test-api lint-ui lint-api quality-gate-ui
+
+dev:
+	make dev-api & make dev-ui
 
 dev-ui:
 	cd ui && npm run dev
@@ -11,6 +14,9 @@ test-ui:
 
 test-api:
 	cd api && uv run pytest tests/ -v
+
+lint-ui:
+	cd ui && npm run lint && npm run format && npm run types:check
 
 lint-api:
 	cd api && uv run ruff check app/ tests/

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -7,7 +7,7 @@ app = FastAPI(title="Inkwell API", version="0.1.0")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=["http://localhost:5173", "http://localhost:5174", "http://localhost:5175"],
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- Adds `dev` Makefile target that runs API and UI dev servers in parallel (`make dev-api & make dev-ui`)
- Adds `lint-ui` Makefile target that runs ESLint, Prettier, and TypeScript type-check for the UI package
- Expands the FastAPI CORS allowlist to include ports 5174 and 5175 alongside the existing 5173
- Updates the branch format example in `.claude/agents/git-agent.md` to use a `chore`-type example

## Test plan
- [ ] Run `make dev` and verify both API and UI servers start
- [ ] Run `make lint-ui` and verify it exits cleanly on a clean codebase
- [ ] Start the API server and confirm requests from `localhost:5174` and `localhost:5175` are not blocked by CORS

🤖 Generated with [Claude Code](https://claude.com/claude-code)