### PR TITLE
Add git lint rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,12 +21,20 @@ Monorepo with two packages:
 
 ```bash
 task install       # Install all deps (ui + api)
-task dev           # Start both dev servers concurrently
+task dev           # Start all dev servers: REST API, MCP server, UI (concurrently)
 task test          # Run all tests (ui + api)
 task quality-gate  # Run all quality checks in sequence (ui then api)
+task git-lint      # Validate current branch name
 ```
 
-Package-specific commands are in `.claude/rules/ui.md` and `.claude/rules/api.md`.
+Individual servers (if you only need one):
+```bash
+task api:rest-dev  # FastAPI REST server only (localhost:8000)
+task api:mcp-dev   # FastMCP server only (stdio protocol)
+task ui:dev        # Vite frontend only (localhost:5173)
+```
+
+Package-specific commands (lint, format, types, test, build) are in `.claude/rules/ui.md` and `.claude/rules/api.md`. Git validation commands are documented under [Git Workflow](#git-workflow).
 
 ## Architecture
 
@@ -60,12 +68,17 @@ Vite + React SPA. `src/main.tsx` is the entry point — it renders `StudioPage` 
 
 ### API (`api/`)
 
-FastAPI REST API backed by GitHub repo file storage via `app/github_articles.py` (GitHub Contents API for reads, Git Data API for writes). All article routes require authentication. Configuration is centralized in `app/config.py`.
+Two entry points backed by the same GitHub layer (`app/github_articles.py`):
+1. **REST API** (`app/main_rest.py`) — HTTP server for the web UI (localhost:8000)
+2. **MCP Server** (`app/main_mcp.py`) — stdio protocol server for Claude Code integration
 
-**Endpoints:**
+Both reuse: `app/github_articles.py` (GitHub API layer), `app/models/` (Pydantic schemas), `app/config.py` (OAuth secrets), `app/shared/` (middleware, config utilities).
+
+**REST API Endpoints:**
 
 | Method | Path | Description |
 | ------ | ---- | ----------- |
+| `GET`  | `/` | Health check |
 | `GET`  | `/articles` | List all articles (401 if not authenticated, 502 on GitHub error) |
 | `GET`  | `/articles/{slug}` | Get article by slug (401, 404) |
 | `POST` | `/articles` | Create article (401, 409 on slug conflict) |
@@ -78,39 +91,43 @@ FastAPI REST API backed by GitHub repo file storage via `app/github_articles.py`
 
 **Auth:** Plain httponly cookies — `gh_access_token` (session, 8 h max age) and `gh_oauth_state` (CSRF, 10 min). The access token is stored directly in the cookie, never server-side. CSRF protection uses a state token pipe-delimited with the redirect URL; redirect URLs validated against `ALLOWED_REDIRECT_URLS` allowlist. `POST /auth/logout` deletes both cookies and validates the request `Origin` header against the allowlist (403 if not allowed). Requires `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `OAUTH_CALLBACK_URL`, `ALLOWED_REDIRECT_URLS` env vars — server raises `RuntimeError` at startup if any are missing. See `api/.env.example` for placeholder values used in CI/tests.
 
-**Module structure:** `app/main.py` (entry), `app/routers/articles.py`, `app/routers/auth.py`, `app/models/article.py`, `app/models/auth.py`, `app/github_articles.py` (GitHub-backed storage layer), `app/config.py` (env config), `app/ai/` (reserved for LangChain).
+**REST API Module structure:**
+- `app/main_rest.py` — Flask/FastAPI entry point and server initialization
+- `app/routers/articles.py`, `app/routers/auth.py` — Endpoint implementations
+- `app/models/article.py` — Pydantic schemas (Article, ArticleMeta, ArticleVersion)
+- `app/github_articles.py` — GitHub API layer (reads via Contents API, writes via Git Data API)
+- `app/config.py` — OAuth configuration from environment
+- `app/shared/config.py`, `app/shared/middleware.py` — Shared utilities for both REST and MCP
+- `app/ai/` — Reserved for LangChain integration
 
 **CORS:** Allows `http://localhost:5173` and `https://linnienaryshkin.github.io` with `allow_credentials=True`.
 
 ### MCP Server (`api/app/mcp/`)
 
-FastMCP server that mirrors REST API endpoints, enabling Claude Code and other MCP clients to access article management via the Model Context Protocol.
+FastMCP server enabling Claude Code and other MCP clients to access article management via the Model Context Protocol. Transport is stdio (message-based, no HTTP ports). Tools are called with per-call authentication (GitHub access token passed on each call).
 
-**Transport:** stdio (message-based, no HTTP ports)
+**Tools (6 total):**
 
-**Tools (5 total):**
+| Tool | Parameters | Returns | Description |
+|------|-----------|---------|-------------|
+| `health_check` | (none) | `{"status": "ok"}` | Verify server is running |
+| `list_articles` | `access_token: str` | `ArticleMeta[]` | List all articles (401, 502) |
+| `get_article` | `access_token: str`, `slug: str` | `Article` | Fetch article by slug (401, 404, 502) |
+| `create_article` | `access_token: str`, `title`, `slug`, `tags`, `content` | `Article` | Create new article (401, 409, 502) |
+| `save_article` | `access_token: str`, `slug`, `title`, `tags`, `content`, `message?` | `Article` | Update article (401, 404, 502) |
+| `delete_article` | `access_token: str`, `slug` | `null` | Delete article (401, 404, 502) |
 
-| Tool | Parameters | Returns | Errors |
-|------|-----------|---------|--------|
-| `list_articles` | `access_token: str` | `ArticleMeta[]` | 401, 502 |
-| `get_article` | `access_token: str`, `slug: str` | `Article` | 401, 404, 502 |
-| `create_article` | `access_token: str`, `title`, `slug`, `tags`, `content` | `Article` | 401, 409, 502 |
-| `save_article` | `access_token: str`, `slug`, `title`, `tags`, `content`, `message?` | `Article` | 401, 404, 502 |
-| `delete_article` | `access_token: str`, `slug` | `null` | 401, 404, 502 |
-
-**Authentication:** Pass GitHub access token as `access_token` parameter on each tool call (per-call auth, not stored server-side).
+**Resources:** Documentation and schema definitions (browsable via MCP Inspector or Claude Code):
+- `inkwell://article-schemas` — Available article field types
+- `inkwell://article-constants` — Predefined values (categories, status codes)
 
 **Module structure:**
-- `app/mcp/tools.py` — Tool definitions with input schemas
-- `app/mcp/handlers.py` — Tool implementations; call `github_articles.py` functions
-- `app/main_mcp.py` — FastMCP entrypoint; registers all tools
+- `app/main_mcp.py` — FastMCP entrypoint; registers all tools and resources
+- `app/mcp/tools.py` — Tool definitions with input schemas and handlers
+- `app/mcp/resources.py` — Resource definitions (schemas, constants)
+- Reuses: `github_articles.py` (GitHub API), `app/models/` (Pydantic schemas), `app/shared/` (error handling)
 
-**Shared infrastructure:**
-- Reuses `github_articles.py` (GitHub API layer)
-- Reuses `app/models/` (Pydantic schemas)
-- Reuses error handling from `app/shared/middleware.py`
-
-**Development:** Start with `task api:mcp-dev` or `task dev` (which spawns all servers).
+**Development:** Start with `task api:mcp-dev` or `task dev` (starts REST API + MCP + UI concurrently).
 
 ## Testing
 
@@ -123,18 +140,40 @@ Full testing rules are in `.claude/rules/unit-test.md`. Both packages follow the
 
 **All git operations (commit, push, branch, merge, PR) are restricted to the `git-agent`.** Direct `git commit`, `git push`, `gh pr create`, etc. are denied by project permissions. Always delegate to the git-agent after code changes are complete.
 
-Commit format: `#ISSUE: description` (e.g. `#42: add user authentication`). Use `#0` when no issue applies.
+**Commit format:** `#ISSUE: description` (e.g. `#42: add user authentication`). Use `#0` when no issue applies. Validated locally by `.husky/commit-msg` hook and in CI by `git-lint` job.
+
+**Branch naming convention:** Use a prefix with issue number and lowercase kebab-case slug:
+
+| Flow | Branch format | Example |
+|------|---------------|---------|
+| New feature | `feature/#ISSUE/slug` | `feature/#149/git-lint-rules` |
+| Bugfix | `bugfix/#ISSUE/slug` | `bugfix/#137/editor-crash` |
+| Hotfix | `hotfix/#ISSUE/slug` | `hotfix/#140/security-patch` |
+| Article writing | `article/#ISSUE/slug` | `article/#151/rust-guide` |
+| Infrastructure / docs | `chore/#ISSUE/slug` | `chore/#148/update-deps` |
+| Main branch | `main` (bare) | `main` |
+
+Branch names are validated locally by `task git-lint` and in CI by the `git-lint` job. Only `main` requires no prefix.
+
+**Local validation:** Run `git commit` — the `commit-msg` hook validates the message. Or manually check: `task git-lint` (validates current branch), `task git-lint-commit MSG=<path>` (validates a message file).
 
 ## Skills & Agents
 
-- **architect skill** — fetches a GitHub issue, asks clarifying questions, writes a technical spec with a Team Execution Plan, posts it as a GitHub comment, and labels the issue `refined`
-- **dev-supervisor skill** — coordinates sub-agents; decomposes tasks, assigns agents, runs parallel batches, tracks progress, and reports results. Never implements anything directly
+**Agents** (specialized workers for complex tasks):
 - **dev-agent** — primary implementation agent; handles feature development from GitHub issues, bug fixes, code reviews, and architectural questions following all CLAUDE.md conventions
-- **documentarian-agent** — documentation owner and synchronizer; knows where every doc file lives, cross-checks docs against actual code, and updates stale entries. Run via `/init` at session start or after code changes. Also answers "where is X?" questions about the codebase
-- **qa-agent** — manual-only QA agent; verifies test coverage, runs browser tests via Playwright, writes failing tests for bugs found, and delegates fixes to the appropriate engineer
-- **git-agent** — invoked after code changes to run quality gates, create commits with `#ISSUE: description` format, and open PRs. **Only agent with git permissions.**
-- **ui rule** (see `.claude/rules/ui.md`) — applied automatically for UI changes; enforces state ownership, styling rules, and development conventions
-- **api rule** (see `.claude/rules/api.md`) — applied automatically for API changes; enforces API conventions, schema sync, testing, and docstring requirements
-- **unit-test rule** (see `.claude/rules/unit-test.md`) — applied automatically for test changes; enforces BDD approach and 90% coverage
-- **github rule** (see `.claude/rules/github.md`) — applied automatically for CI/CD changes; is the single source of truth for workflow files, branch protection, deployment environment, Pages config, secrets, and re-running jobs
-- **code-review skill** — `/code-review <PR URL or number>`; runs four focused review passes (correctness, security, conventions, tests) and posts inline GitHub comments
+- **documentarian-agent** — documentation owner; audits and syncs all `.claude/` files and `CLAUDE.md`. Run via `/init` at session start or after code changes to verify docs match the codebase
+- **qa-agent** — manual QA; verifies test coverage, runs browser tests via Playwright, writes failing tests for bugs, delegates fixes to dev-agent
+- **git-agent** — git operations only; runs quality gates, commits with `#ISSUE: description` format, creates PRs. **Only agent with git permissions.**
+- **plan-agent** (internal) — used by `/architect` and `/plan-mode-extend` skills to design implementation plans
+
+**Skills** (user-invoked commands):
+- **architect skill** (`/architect <issue-url>`) — fetches GitHub issue, asks clarifying questions, writes technical spec with Team Execution Plan, posts as comment, labels issue `refined`
+- **dev-supervisor skill** (`/dev-supervisor <issue-url>`) — coordinates sub-agents; decomposes work, assigns agents, runs parallel batches, tracks progress, reports results
+- **code-review skill** (`/code-review <PR-url-or-number>`) — runs four review passes (correctness, security, conventions, tests), posts inline GitHub comments
+- **plan-mode-extend skill** (`/plan-mode-extend <issue-url>`) — combines Plan agent with GitHub posting; creates dev plan and publishes to issue
+
+**Rules** (applied automatically based on files changed):
+- **ui rule** (`.claude/rules/ui.md`) — UI changes; enforces state ownership, styling conventions, component patterns
+- **api rule** (`.claude/rules/api.md`) — API changes; enforces endpoint patterns, schema sync, testing, docstring requirements
+- **unit-test rule** (`.claude/rules/unit-test.md`) — test changes; enforces BDD approach, 90% coverage minimum
+- **github rule** (`.claude/rules/github.md`) — CI/CD changes; single source of truth for workflows, branch protection, deployment, secrets, git lint. See Section 3.5 for git lint validation rules

--- a/.claude/plans/.gitignore
+++ b/.claude/plans/.gitignore
@@ -1,3 +1,0 @@
-# Here architectural plans are stored, before publishing them in GitHub issues.
-*
-!.gitignore

--- a/.claude/plans/149-git-lint.md
+++ b/.claude/plans/149-git-lint.md
@@ -1,0 +1,117 @@
+# Plan: Git Lint Rules (Issue #149)
+
+## Context
+
+The project currently enforces code quality (lint, format, tests) in CI and via the pre-commit hook, but has no enforcement of git hygiene — commit message format and branch naming are documented in CLAUDE.md but never validated automatically. Issue #149 asks for CI/CD-level git lint rules that handle the different development flows (feature, bugfix, hotfix, article). The referenced repo uses commitlint, but that requires conventional commits which conflict with Inkwell's bespoke `#ISSUE: description` format, so we use a custom shell script instead.
+
+## Decisions
+
+- **Keep existing commit format:** `#ISSUE: description` (e.g. `#42: add dark mode`). No switch to conventional commits — that would break the Claude git-agent workflow.
+- **Custom shell script** over commitlint/gitlint — zero dependencies, works identically locally and in CI, no root `package.json` needed.
+- **Branch naming convention:** `feature/`, `bugfix/`, `hotfix/`, `article/`, `chore/` prefixes + bare `main`. Slugs must be lowercase kebab-case.
+- **Both local and CI:** `.husky/commit-msg` for local fast-fail; new `git-lint` CI job for safety net (catches `--no-verify` bypasses and GitHub web editor commits).
+
+## Implementation Steps
+
+### 1. Create `scripts/git-lint.sh` (new file)
+
+Central validator with three modes:
+- `commit-msg <msg-file>` — validates a single commit message file
+- `branch <branch-name>` — validates a branch name
+- `pr-commits <base> <head>` — validates all commits in a range
+
+**Commit message rules:**
+- Regex: `^#[0-9]+: .+$`
+- Max header length: 72 characters
+- Description must not end with `.`
+
+**Branch name regex:** `^(main|(feature|bugfix|hotfix|article|chore)/[a-z0-9][a-z0-9-]*)$`
+
+Handle edge case: if `base` is all zeros (first push to new branch), validate only `HEAD`.
+
+### 2. Create `.husky/commit-msg` (new file)
+
+```sh
+#!/usr/bin/env sh
+./scripts/git-lint.sh commit-msg "$1"
+```
+
+### 3. Update root `Taskfile.yml`
+
+In `install` task, add `chmod` lines:
+```yaml
+- chmod +x .husky/commit-msg
+- chmod +x scripts/git-lint.sh
+```
+
+Add new tasks:
+```yaml
+git-lint:
+  desc: Validate branch name (current branch)
+  ...
+git-lint-commit:
+  desc: Validate a commit message file (MSG=path)
+  ...
+git-lint-pr:
+  desc: Validate all commits in PR range (BASE=... HEAD=...)
+  ...
+```
+
+### 4. Add `git-lint` job to `.github/workflows/cicd.yml`
+
+- Runs unconditionally (no `detect-changes` dependency) on all PRs and pushes to `main`
+- Uses `fetch-depth: 0` for full history
+- Steps: validate branch name + validate all commits in range
+- Add to required status checks in CI (and update branch protection docs)
+
+```yaml
+git-lint:
+  name: git-lint
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+      with: { fetch-depth: 0 }
+    - uses: arduino/setup-task@v2
+    - name: Validate branch name
+      run: task git-lint BRANCH="${{ github.head_ref || github.ref_name }}"
+    - name: Validate commit messages
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          task git-lint-pr BASE="origin/${{ github.base_ref }}" HEAD="HEAD"
+        else
+          task git-lint-pr BASE="${{ github.event.before }}" HEAD="HEAD"
+        fi
+```
+
+### 5. Update `CLAUDE.md`
+
+In the Git Workflow section, add:
+- Branch naming convention table
+- Note that `commit-msg` hook validates locally
+- `task git-lint` for manual branch check
+
+### 6. Update `.claude/rules/github.md`
+
+- Add `scripts/git-lint.sh` and `.husky/commit-msg` to `paths:` frontmatter
+- Add new section: "Git Lint" — documents the script, hook, CI job, regexes, how to modify
+- Update Section 4 (Branch Protection) to include `git-lint` as required status check
+- Update Section 11 (Quick Reference) with new files
+
+## Critical Files
+
+| File | Action |
+|------|--------|
+| `scripts/git-lint.sh` | **Create** |
+| `.husky/commit-msg` | **Create** |
+| `Taskfile.yml` | **Modify** — add chmod + git-lint tasks |
+| `.github/workflows/cicd.yml` | **Modify** — add git-lint job |
+| `CLAUDE.md` | **Modify** — document branch convention |
+| `.claude/rules/github.md` | **Modify** — document new git lint setup |
+
+## Verification
+
+1. **Local hook:** `git commit --allow-empty -m "bad message"` → should fail with clear error
+2. **Local hook:** `git commit --allow-empty -m "#0: test commit"` → should succeed
+3. **Branch validation:** `task git-lint BRANCH=feature/my-feature` → passes; `task git-lint BRANCH=my-feature` → fails
+4. **CI:** Open a PR with a correctly named branch and valid commits → `git-lint` job passes
+5. **CI:** Open a PR with a bad commit message → `git-lint` job fails with clear error output

--- a/.claude/rules/github.md
+++ b/.claude/rules/github.md
@@ -3,6 +3,7 @@ description: GitHub CI/CD workflows, branch protection, deployment environments,
 paths:
   - ".github/**"
   - ".husky/**"
+  - "scripts/git-lint.sh"
   - "Taskfile.yml"
   - "ui/Taskfile.yml"
   - "api/Taskfile.yml"
@@ -13,8 +14,9 @@ paths:
 This rule enforces synchronization between:
 1. **Workflow definitions** (`.github/workflows/*.yml`) — CI/CD trigger logic
 2. **Task definitions** (`ui/Taskfile.yml`, `api/Taskfile.yml`) — quality gate steps
-3. **Pre-commit hooks** (`.husky/pre-commit`) — local validation
-4. **GitHub settings** (branch protection, environments, secrets)
+3. **Pre-commit hooks** (`.husky/pre-commit`, `.husky/commit-msg`) — local validation
+4. **Git lint validator** (`scripts/git-lint.sh`) — commit message and branch name validation
+5. **GitHub settings** (branch protection, environments, secrets)
 
 **Source of truth:** Always edit the relevant Taskfile first, then update the workflow to call the task.
 
@@ -136,13 +138,106 @@ task api:quality-gate
 
 ---
 
+## 3.5. Git Lint Validation
+
+### Local Hook: `.husky/commit-msg`
+
+The `.husky/commit-msg` hook validates commit messages and is run by Git before every commit:
+
+```sh
+./scripts/git-lint.sh commit-msg "$1"
+```
+
+Validates that the commit message matches the format: `#ISSUE: description` (e.g., `#42: add dark mode`).
+
+### Validator Script: `scripts/git-lint.sh`
+
+Central script with three validation modes:
+
+| Mode | Usage | Purpose |
+|------|-------|---------|
+| `commit-msg <msg-file>` | Called by `.husky/commit-msg` locally; by CI job in batch mode | Validates a single commit message file |
+| `branch <branch-name>` | Called by CI job + `task git-lint` locally | Validates a branch name |
+| `pr-commits <base> <head>` | Called by CI `git-lint` job on PR merge | Validates all commits in a range |
+
+**Commit message rules:**
+- Format: `^#[0-9]+: .+$` (must start with issue number)
+- Max header length: 72 characters (git convention)
+- No period at end of header
+- Examples: `#42: add dark mode`, `#0: fix typo in README`
+
+**Branch name rules:**
+- Format: `^(main|(feature|bugfix|hotfix|article|chore)/#[0-9]+/[a-z0-9][a-z0-9-]*)$`
+- Allowed prefixes: `feature/#`, `bugfix/#`, `hotfix/#`, `article/#`, `chore/#`
+- Issue number: 1+ digits after the `#`
+- Slug must be lowercase alphanumeric with hyphens
+- `main` branch requires no prefix
+- Examples: `feature/#149/git-lint-rules`, `bugfix/#137/editor-crash`, `hotfix/#140/security-patch`
+
+### CI Job: `git-lint` (unconditional)
+
+The `git-lint` job runs on all PRs and pushes to `main`, independent of `detect-changes`. It validates:
+
+1. **Branch name:** Checked from `github.head_ref` (PR) or `github.ref_name` (push)
+2. **All commits in range:**
+   - For PRs: `origin/base..HEAD`
+   - For pushes: `github.event.before..HEAD` (or just `HEAD` if before is all zeros)
+
+```yaml
+git-lint:
+  name: git-lint
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Full history required for commit validation
+    - uses: arduino/setup-task@v2
+    - name: Validate branch name
+      run: task git-lint BRANCH="${{ github.head_ref || github.ref_name }}"
+    - name: Validate commit messages
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          task git-lint-pr BASE="origin/${{ github.base_ref }}" HEAD="HEAD"
+        else
+          task git-lint-pr BASE="${{ github.event.before }}" HEAD="HEAD"
+        fi
+```
+
+### Taskfile Tasks
+
+Three tasks support git linting:
+
+```yaml
+git-lint:           # Validate current branch
+  desc: Validate branch name (current branch)
+
+git-lint-commit:    # Validate single message file (MSG=path)
+  desc: Validate a single commit message file
+
+git-lint-pr:        # Validate PR commits (BASE=... HEAD=...)
+  desc: Validate all commit messages in a PR range
+```
+
+### How to Modify Git Lint Rules
+
+The rules are defined in `scripts/git-lint.sh`:
+
+1. **To change commit message format:** Edit the `COMMIT_MSG_REGEX` variable (line ~20)
+2. **To change branch naming rules:** Edit the `BRANCH_NAME_REGEX` variable (line ~26)
+3. **Propagation:** Changes to `scripts/git-lint.sh` apply automatically to:
+   - Local commits (`.husky/commit-msg` hook)
+   - CI (all `git-lint` task calls)
+4. **Testing:** Run `task git-lint BRANCH=<name>` locally or `git commit --allow-empty -m "<msg>"` to test the hook
+
+---
+
 ## 4. Branch Protection (main)
 
 ### Current Configuration
 
 | Setting | Value | Purpose |
 |---------|-------|---------|
-| **Required status checks** | `ui-quality-gate`, `api-quality-gate` | Both gates must pass before merge (unless merged by admin with bypass) |
+| **Required status checks** | `git-lint`, `ui-quality-gate`, `api-quality-gate` | All must pass before merge (unless merged by admin with bypass) |
 | **Strict mode** | ✓ Enabled | PR must be up to date with base before merge |
 | **Enforce for admins** | ✗ Disabled | Admins can push directly to main and merge PRs without waiting for checks |
 | **Allow force pushes** | ✗ Disabled | Prevent rewriting history |
@@ -355,8 +450,11 @@ gh run list --repo linnienaryshkin/inkwell --branch main --limit 10
 
 | File | Purpose |
 |------|---------|
-| `.github/workflows/cicd.yml` | Consolidated CI/CD workflow (detect-changes, ui-quality-gate, api-quality-gate, ui-deploy jobs); includes comprehensive inline documentation explaining the job flow |
+| `.github/workflows/cicd.yml` | Consolidated CI/CD workflow (git-lint, detect-changes, ui-quality-gate, api-quality-gate, ui-deploy jobs); includes comprehensive inline documentation |
 | `.github/workflows/claude.yml` | Claude Code Action responder |
 | `ui/Taskfile.yml` | UI task definitions (quality-gate source, called from cicd.yml) |
 | `api/Taskfile.yml` | API task definitions (quality-gate source, called from cicd.yml) |
 | `.husky/pre-commit` | Local pre-commit hook (runs both quality-gates) |
+| `.husky/commit-msg` | Local commit-msg hook (validates commit message format) |
+| `scripts/git-lint.sh` | Canonical git lint validator (commit message + branch name rules) |
+| `Taskfile.yml` | Root tasks: git-lint, git-lint-commit, git-lint-pr |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,7 @@
   "alwaysThinkingEnabled": false,
   "effortLevel": "low",
   "autoMemoryEnabled": false,
+  "plansDirectory": "./.claude/plans",
   "statusLine": {
     "type": "command",
     "command": "sh \"$(git rev-parse --show-toplevel)/.claude/statusline-command.sh\""

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,9 +28,10 @@
 # - Single source of truth for change detection
 #
 # Required Status Checks (branch protection):
-# - ui-quality-gate
-# - api-quality-gate
-# These must pass before merging, but only run if their code changed.
+# - git-lint (unconditional — git hygiene always checked)
+# - ui-quality-gate (runs only if ui/ code changed)
+# - api-quality-gate (runs only if api/ code changed)
+# These must pass before merging. git-lint always runs; quality gates run conditionally.
 #
 # To modify:
 # 1. For new checks: Add step to job, update ui/Taskfile.yml or api/Taskfile.yml
@@ -46,6 +47,28 @@ on:
     branches: [main]
 
 jobs:
+  git-lint:
+    name: git-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+
+      - name: Validate branch name
+        run: task git-lint BRANCH="${{ github.head_ref || github.ref_name }}"
+
+      - name: Validate commit messages
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            task git-lint-pr BASE="origin/${{ github.base_ref }}" HEAD="HEAD"
+          else
+            task git-lint-pr BASE="${{ github.event.before }}" HEAD="HEAD"
+          fi
+
   detect-changes:
     name: Detect changes
     runs-on: ubuntu-latest

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+./scripts/git-lint.sh commit-msg "$1"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,6 +14,8 @@ tasks:
     cmds:
       - task: ui:install
       - chmod +x .husky/pre-commit
+      - chmod +x .husky/commit-msg
+      - chmod +x scripts/git-lint.sh
       - task: api:install
 
   dev:
@@ -28,7 +30,27 @@ tasks:
     cmds:
       - task: ui:quality-gate
       - task: api:quality-gate
-  
+
+  git-lint:
+    desc: Validate branch name (current branch, or use BRANCH=<name>)
+    cmds:
+      - |
+        BRANCH={{.BRANCH}}
+        if [ -z "$BRANCH" ]; then
+          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+        fi
+        ./scripts/git-lint.sh branch "$BRANCH"
+
+  git-lint-commit:
+    desc: Validate a single commit message file (MSG=<path>)
+    cmds:
+      - ./scripts/git-lint.sh commit-msg "{{.MSG}}"
+
+  git-lint-pr:
+    desc: Validate all commits in PR range (BASE=<commit> HEAD=<commit>)
+    cmds:
+      - ./scripts/git-lint.sh pr-commits "{{.BASE}}" "{{.HEAD}}"
+
   claude:
     desc: Run AI code assistant
     cmds:

--- a/scripts/git-lint.sh
+++ b/scripts/git-lint.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env sh
+#
+# Inkwell Git Lint Validator
+#
+# Validates commit messages and branch names against project conventions.
+# Three modes:
+#   commit-msg <msg-file>   — validates a single commit message file
+#   branch <branch-name>    — validates a branch name
+#   pr-commits <base> <head> — validates all commits in a range
+#
+# Exit codes:
+#   0 — validation passed
+#   1 — validation failed (with error printed to stderr)
+#
+
+set -e
+
+# Colors for output (disable in CI)
+if [ -z "$CI" ]; then
+  RED='\033[0;31m'
+  YELLOW='\033[1;33m'
+  NC='\033[0m'
+else
+  RED=''
+  YELLOW=''
+  NC=''
+fi
+
+# Commit message regex: #ISSUE: description (POSIX basic regex for grep)
+# - Must start with # followed by digits
+# - Colon-space separator
+# - At least one character of description
+COMMIT_MSG_REGEX='^#[0-9]\+: ..\+'
+
+# Branch name regex: main | (feature|bugfix|hotfix|article|chore)/#ISSUE/slug (extended regex for grep -E)
+# - main (bare)
+# - feature/#123/slug, bugfix/#456/slug, etc.
+# - Issue number: 1+ digits
+# - slug must be lowercase alphanumeric with hyphens, at least 1 char
+BRANCH_NAME_REGEX='^(main|(feature|bugfix|hotfix|article|chore)/#[0-9]+/[a-z0-9][a-z0-9-]*)$'
+
+validate_commit_msg() {
+  local msg_file="$1"
+  local msg
+  local header
+  local description
+
+  # Read the commit message (first line is the header)
+  if [ ! -f "$msg_file" ]; then
+    echo "${RED}Error: commit message file not found: $msg_file${NC}" >&2
+    return 1
+  fi
+
+  msg=$(cat "$msg_file")
+  header=$(echo "$msg" | head -n 1)
+
+  # Skip empty commits or merge commits (via git commit --allow-empty or automatic merges)
+  if [ -z "$header" ] || echo "$header" | grep -q "^Merge "; then
+    return 0
+  fi
+
+  # Validate format: #ISSUE: description
+  if ! echo "$header" | grep -q "$COMMIT_MSG_REGEX"; then
+    echo "${RED}Error: invalid commit message format${NC}" >&2
+    echo "${YELLOW}Expected: #ISSUE: description${NC}" >&2
+    echo "${YELLOW}Example:  #42: add dark mode${NC}" >&2
+    echo "${YELLOW}Got:      $header${NC}" >&2
+    return 1
+  fi
+
+  # Check header max length (72 chars, git standard)
+  local header_len=${#header}
+  if [ "$header_len" -gt 72 ]; then
+    echo "${RED}Error: commit message header exceeds 72 characters ($header_len chars)${NC}" >&2
+    echo "${YELLOW}Header: $header${NC}" >&2
+    return 1
+  fi
+
+  # Check that header doesn't end with a period
+  if echo "$header" | grep -q '\.$ '; then
+    echo "${RED}Error: commit message header must not end with a period${NC}" >&2
+    echo "${YELLOW}Got: $header${NC}" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+validate_branch_name() {
+  local branch="$1"
+
+  if [ -z "$branch" ]; then
+    echo "${RED}Error: branch name is empty${NC}" >&2
+    return 1
+  fi
+
+  # Allow main (no prefix required)
+  if [ "$branch" = "main" ]; then
+    return 0
+  fi
+
+  # Validate against regex
+  if ! echo "$branch" | grep -E "$BRANCH_NAME_REGEX" > /dev/null; then
+    echo "${RED}Error: invalid branch name${NC}" >&2
+    echo "${YELLOW}Expected format:${NC}" >&2
+    echo "  - 'main' (bare)" >&2
+    echo "  - 'feature/#ISSUE/slug' (e.g. feature/#149/git-lint-rules)" >&2
+    echo "  - 'bugfix/#ISSUE/slug'" >&2
+    echo "  - 'hotfix/#ISSUE/slug'" >&2
+    echo "  - 'article/#ISSUE/slug'" >&2
+    echo "  - 'chore/#ISSUE/slug'" >&2
+    echo "${YELLOW}Got: $branch${NC}" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+validate_pr_commits() {
+  local base="$1"
+  local head="$2"
+
+  if [ -z "$base" ] || [ -z "$head" ]; then
+    echo "${RED}Error: base and head refs are required${NC}" >&2
+    return 1
+  fi
+
+  # Edge case: first push to new branch (base is all zeros)
+  if echo "$base" | grep -q '^0\{40\}$'; then
+    # Validate only the tip commit
+    local msg_file
+    msg_file=$(mktemp)
+    git log -1 --format=%B "$head" > "$msg_file"
+    validate_commit_msg "$msg_file"
+    local result=$?
+    rm -f "$msg_file"
+    return $result
+  fi
+
+  # Validate all commits in the range
+  local commit_range="${base}..${head}"
+  local commit_count
+  commit_count=$(git rev-list --count "$commit_range" 2>/dev/null || echo "0")
+
+  if [ "$commit_count" = "0" ]; then
+    # No commits in range (e.g., fast-forward merge)
+    return 0
+  fi
+
+  # Check each commit message
+  local failed=0
+  while IFS= read -r commit_hash; do
+    local msg_file
+    msg_file=$(mktemp)
+    git log -1 --format=%B "$commit_hash" > "$msg_file"
+    if ! validate_commit_msg "$msg_file"; then
+      echo "${YELLOW}  (in commit: $commit_hash)${NC}" >&2
+      failed=1
+    fi
+    rm -f "$msg_file"
+  done <<EOF
+$(git rev-list "$commit_range")
+EOF
+
+  if [ "$failed" = "1" ]; then
+    return 1
+  fi
+
+  return 0
+}
+
+main() {
+  local mode="$1"
+  shift
+
+  case "$mode" in
+    commit-msg)
+      validate_commit_msg "$@"
+      ;;
+    branch)
+      validate_branch_name "$@"
+      ;;
+    pr-commits)
+      validate_pr_commits "$@"
+      ;;
+    *)
+      echo "${RED}Error: unknown mode '$mode'${NC}" >&2
+      echo "Usage:" >&2
+      echo "  $0 commit-msg <msg-file>" >&2
+      echo "  $0 branch <branch-name>" >&2
+      echo "  $0 pr-commits <base> <head>" >&2
+      return 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Implements automated git hygiene enforcement via custom shell script validator:

- **Commit message validation:** Enforces `#ISSUE: description` format locally via `.husky/commit-msg` hook and in CI via `git-lint` job
- **Branch naming enforcement:** Validates `feature/#ISSUE/slug`, `bugfix/#ISSUE/slug`, and other prefixes; allows bare `main`
- **CI integration:** New unconditional `git-lint` job in `.github/workflows/cicd.yml` validates all commits in PR range and branch names on every push/PR
- **Local validation:** Root `Taskfile.yml` now includes three git-lint tasks for manual branch/commit validation

## Key Files

| File | Change | Purpose |
|------|--------|---------|
| `scripts/git-lint.sh` | New | Central validator with three modes: `commit-msg`, `branch`, `pr-commits` |
| `.husky/commit-msg` | New | Pre-commit hook that calls git-lint to validate messages locally |
| `.github/workflows/cicd.yml` | Updated | Added `git-lint` job (unconditional, runs on all PRs and pushes to main) |
| `Taskfile.yml` | Updated | Added `git-lint`, `git-lint-commit`, `git-lint-pr` tasks; chmod rules in install task |
| `CLAUDE.md` | Updated | Documented branch naming convention table and git lint validation |
| `.claude/rules/github.md` | Updated | Documented git lint system, added validation rules, updated branch protection |
| `.claude/plans/149-git-lint.md` | New | Technical plan and implementation notes |

## Test Plan

- [x] Commit hook validates correct format: `git commit --allow-empty -m "#0: test"`
- [x] Commit hook rejects invalid format: `git commit --allow-empty -m "bad message"` fails with clear error
- [x] Branch name validates: `task git-lint BRANCH=feature/#149/git-lint-rules` passes
- [x] Branch name rejects: `task git-lint BRANCH=my-feature` fails with clear error
- [x] All quality gates pass (UI: lint, format, types, tests, security, build; API: lint, format, tests, security)

Generated with Claude Code