### PR TITLE
feature/#156: redesign UI/UX from Claude Design export

### DIFF
--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -145,3 +145,14 @@ body {
     transform: rotate(360deg);
   }
 }
+
+@keyframes inkwell-blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}

--- a/ui/src/app/studio/page.test.tsx
+++ b/ui/src/app/studio/page.test.tsx
@@ -82,11 +82,18 @@ const mockLogout = logout as jest.MockedFunction<typeof logout>;
 const mockCreateArticle = createArticle as jest.MockedFunction<typeof createArticle>;
 const mockSaveArticle = saveArticle as jest.MockedFunction<typeof saveArticle>;
 
+const defaultUser = {
+  login: "testuser",
+  name: "Test User",
+  avatar_url: "https://example.com/a.png",
+};
+
 describe("StudioPage", () => {
   beforeEach(() => {
     mockFetchArticles.mockRejectedValue(new Error("API unavailable"));
     mockFetchArticle.mockRejectedValue(new Error("API unavailable"));
-    mockFetchCurrentUser.mockRejectedValue(new Error("Not authenticated"));
+    // Default: authenticated so the studio renders; individual tests override as needed
+    mockFetchCurrentUser.mockResolvedValue(defaultUser);
     mockCreateArticle.mockReset();
     mockSaveArticle.mockReset();
     mockLogout.mockReset();
@@ -175,7 +182,8 @@ describe("StudioPage", () => {
   describe("Header Layout", () => {
     it("should render header with Inkwell title", () => {
       render(<StudioPage />);
-      expect(screen.getByText("Inkwell")).toBeInTheDocument();
+      expect(screen.getByText("inkwell")).toBeInTheDocument();
+      expect(screen.getByText("write · commit · publish")).toBeInTheDocument();
     });
 
     it("should render theme toggle button", () => {
@@ -189,13 +197,16 @@ describe("StudioPage", () => {
 
   describe("GitHub OAuth UI", () => {
     it("renders Sign in with GitHub link when unauthenticated", async () => {
+      mockFetchCurrentUser.mockRejectedValue(new Error("Not authenticated"));
       render(<StudioPage />);
       await waitFor(() => {
-        expect(screen.getByRole("link", { name: /sign in with github/i })).toBeInTheDocument();
+        const links = screen.getAllByRole("link", { name: /sign in with github/i });
+        expect(links.length).toBeGreaterThan(0);
       });
     });
 
     it("does not render avatar when unauthenticated", async () => {
+      mockFetchCurrentUser.mockRejectedValue(new Error("Not authenticated"));
       render(<StudioPage />);
       await waitFor(() => {
         expect(screen.queryByRole("img")).not.toBeInTheDocument();
@@ -246,6 +257,7 @@ describe("StudioPage", () => {
     });
 
     it("does not render profile menu trigger when unauthenticated", async () => {
+      mockFetchCurrentUser.mockRejectedValue(new Error("Not authenticated"));
       render(<StudioPage />);
       await waitFor(() => {
         expect(
@@ -285,7 +297,8 @@ describe("StudioPage", () => {
       expect(mockLogout).toHaveBeenCalledTimes(1);
       await waitFor(() => {
         expect(screen.queryByRole("img")).not.toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /sign in with github/i })).toBeInTheDocument();
+        const links = screen.getAllByRole("link", { name: /sign in with github/i });
+        expect(links.length).toBeGreaterThan(0);
       });
     });
 
@@ -298,7 +311,8 @@ describe("StudioPage", () => {
       const signOutItem = screen.getByRole("menuitem", { name: /sign out/i });
       await userEvent.click(signOutItem);
       await waitFor(() => {
-        expect(screen.getByRole("link", { name: /sign in with github/i })).toBeInTheDocument();
+        const links = screen.getAllByRole("link", { name: /sign in with github/i });
+        expect(links.length).toBeGreaterThan(0);
       });
     });
   });

--- a/ui/src/app/studio/page.tsx
+++ b/ui/src/app/studio/page.tsx
@@ -71,6 +71,173 @@ function titleToSlug(title: string): string {
     .slice(0, 100);
 }
 
+function SignedOutLanding({
+  theme,
+  onToggleTheme,
+}: {
+  theme: "dark" | "light";
+  onToggleTheme: () => void;
+}) {
+  return (
+    <div className="flex flex-col h-screen">
+      {/* Header */}
+      <header
+        className="flex items-center justify-between px-5 py-3 border-b"
+        style={{ borderColor: "var(--border)", background: "var(--bg-secondary)" }}
+      >
+        <div className="flex items-center gap-3">
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 17,
+              fontWeight: 500,
+              fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
+              color: "var(--text-primary)",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            <span style={{ color: "var(--accent)", fontWeight: 600 }}>$</span>
+            <span>inkwell</span>
+            <span
+              style={{
+                display: "inline-block",
+                width: 8,
+                height: 14,
+                marginLeft: 2,
+                background: "var(--text-primary)",
+                animation: "inkwell-blink 1.06s steps(1, end) infinite",
+              }}
+            />
+          </h1>
+          <span
+            style={{
+              fontSize: 9,
+              color: "var(--text-secondary)",
+              textTransform: "uppercase",
+              letterSpacing: "0.18em",
+            }}
+          >
+            write · commit · publish
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <a
+            href="https://github.com/linnienaryshkin/inkwell"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Visit Inkwell GitHub repository"
+            aria-label="Visit Inkwell GitHub repository"
+            className="inline-flex items-center justify-center p-1 transition-colors"
+            style={{ color: "var(--text-secondary)" }}
+            onMouseEnter={(e) => (e.currentTarget.style.color = "var(--text-primary)")}
+            onMouseLeave={(e) => (e.currentTarget.style.color = "var(--text-secondary)")}
+          >
+            <FaGithub size={20} />
+          </a>
+          <button
+            onClick={onToggleTheme}
+            title={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+            className="text-xs px-2 py-1 rounded border"
+            style={{
+              background: "var(--bg-tertiary)",
+              border: "1px solid var(--border)",
+              color: "var(--text-secondary)",
+              cursor: "pointer",
+            }}
+          >
+            {theme === "dark" ? "☀ Light" : "☾ Dark"}
+          </button>
+          <a
+            href={getLoginUrl()}
+            aria-label="Sign in with GitHub"
+            className="inline-flex items-center gap-1 px-2 rounded text-sm"
+            style={{
+              background: "var(--accent)",
+              color: "var(--bg-primary)",
+              height: "40px",
+              width: "180px",
+              justifyContent: "center",
+            }}
+          >
+            <FaGithub size={16} />
+            Sign in with GitHub
+          </a>
+        </div>
+      </header>
+
+      {/* Landing body */}
+      <div
+        className="flex-1 flex items-center justify-center"
+        style={{ background: "var(--bg-primary)", padding: 48 }}
+      >
+        <div className="flex flex-col items-center gap-5 text-center" style={{ maxWidth: 520 }}>
+          <div
+            style={{
+              fontSize: 48,
+              fontWeight: 600,
+              letterSpacing: "-0.02em",
+              color: "var(--accent)",
+              lineHeight: 1,
+            }}
+          >
+            Inkwell
+          </div>
+          <p style={{ fontSize: 18, color: "var(--text-primary)", margin: 0, lineHeight: 1.5 }}>
+            A personal writing studio backed by your GitHub repo.
+          </p>
+          <p
+            style={{
+              fontSize: 14,
+              color: "var(--text-secondary)",
+              margin: 0,
+              lineHeight: 1.6,
+              maxWidth: 440,
+            }}
+          >
+            Articles are stored as files. Versions are commits. Lint, publish to dev.to, and export
+            anywhere — all without leaving the editor.
+          </p>
+          <a
+            href={getLoginUrl()}
+            aria-label="Sign in with GitHub"
+            className="inline-flex items-center gap-2 rounded font-medium"
+            style={{
+              padding: "12px 20px",
+              fontSize: 15,
+              background: "var(--accent)",
+              color: "var(--bg-primary)",
+              textDecoration: "none",
+              marginTop: 8,
+            }}
+          >
+            <FaGithub size={18} />
+            Sign in with GitHub
+          </a>
+          <div
+            className="flex gap-8 pt-6 border-t w-full justify-center"
+            style={{ marginTop: 28, borderColor: "var(--border)" }}
+          >
+            {[
+              { label: "Markdown editor", sub: "Monaco, with preview" },
+              { label: "Git versions", sub: "Every save is a commit" },
+              { label: "Multi-publish", sub: "dev.to, Hashnode, Medium…" },
+            ].map((f) => (
+              <div key={f.label} className="flex flex-col gap-1">
+                <span style={{ fontSize: 12, color: "var(--text-primary)", fontWeight: 500 }}>
+                  {f.label}
+                </span>
+                <span style={{ fontSize: 11, color: "var(--text-secondary)" }}>{f.sub}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function ProfileMenu({
   anchorRef,
   onLogout,
@@ -394,6 +561,16 @@ export default function StudioPage() {
     document.documentElement.setAttribute("data-theme", theme);
   }, [theme]);
 
+  // Show landing page when signed out (and not in the initial loading phase)
+  if (!appLoading && currentUser === null) {
+    return (
+      <SignedOutLanding
+        theme={theme}
+        onToggleTheme={() => setTheme((t) => (t === "dark" ? "light" : "dark"))}
+      />
+    );
+  }
+
   return (
     <div className="flex flex-col h-screen">
       {/* Header */}
@@ -411,11 +588,40 @@ export default function StudioPage() {
         }}
       >
         <div className="flex items-center gap-3">
-          <h1 className="text-lg font-semibold tracking-tight" style={{ color: "var(--accent)" }}>
-            Inkwell
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 17,
+              fontWeight: 500,
+              fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
+              color: "var(--text-primary)",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            <span style={{ color: "var(--accent)", fontWeight: 600 }}>$</span>
+            <span>inkwell</span>
+            <span
+              style={{
+                display: "inline-block",
+                width: 8,
+                height: 14,
+                marginLeft: 2,
+                background: "var(--text-primary)",
+                animation: "inkwell-blink 1.06s steps(1, end) infinite",
+              }}
+            />
           </h1>
-          <span className="text-xs" style={{ color: "var(--text-secondary)" }}>
-            Personal Writing Studio
+          <span
+            style={{
+              fontSize: 9,
+              color: "var(--text-secondary)",
+              textTransform: "uppercase",
+              letterSpacing: "0.18em",
+            }}
+          >
+            write · commit · publish
           </span>
         </div>
         <div className="flex items-center gap-3">

--- a/ui/src/components/ChatTab.tsx
+++ b/ui/src/components/ChatTab.tsx
@@ -114,7 +114,7 @@ export default function ChatTab() {
       {/* Top: Thread List (hidden when a thread is selected) */}
       {!activeThreadId && (
         <div className="flex-shrink-0">
-          <div className="max-h-32 overflow-y-auto space-y-1 pr-2">
+          <div style={{ maxHeight: 96, overflow: "hidden" }} className="space-y-1">
             {threads.length === 0 ? (
               <p className="text-text-secondary text-xs px-2">No threads yet</p>
             ) : (
@@ -174,12 +174,15 @@ export default function ChatTab() {
                   className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
                 >
                   <div
-                    className={`max-w-xs px-3 py-2 rounded text-sm ${
+                    className={`px-3 py-2 rounded text-sm ${
                       msg.role === "user"
                         ? "bg-accent"
                         : "border border-border bg-bg-primary text-text-primary"
                     }`}
-                    style={msg.role === "user" ? { color: "var(--bg-primary)" } : undefined}
+                    style={{
+                      maxWidth: "85%",
+                      ...(msg.role === "user" ? { color: "var(--bg-primary)" } : {}),
+                    }}
                   >
                     <ReactMarkdown
                       remarkPlugins={[remarkGfm]}
@@ -247,8 +250,13 @@ export default function ChatTab() {
           <button
             onClick={handleSend}
             disabled={loading || !inputValue.trim()}
-            className="px-3 py-2 rounded bg-accent hover:bg-accent-hover hover:scale-110 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 cursor-pointer flex items-center justify-center"
-            style={{ color: "var(--bg-primary)" }}
+            className="rounded bg-accent hover:bg-accent-hover hover:scale-110 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 cursor-pointer flex items-center justify-center"
+            style={{
+              color: "var(--bg-primary)",
+              padding: "8px 14px",
+              fontSize: 16,
+              fontWeight: 600,
+            }}
             title="Send message (Enter)"
             aria-label="Send message (Enter)"
           >

--- a/ui/src/components/EditorPane.test.tsx
+++ b/ui/src/components/EditorPane.test.tsx
@@ -582,4 +582,118 @@ describe("EditorPane", () => {
       expect(addBtn.style.color).toBe("var(--text-secondary)");
     });
   });
+
+  describe("Tag input keyboard shortcuts", () => {
+    it("dismisses tag input on Escape without adding a tag", () => {
+      const handleTagsChange = jest.fn();
+      render(
+        <EditorPane article={mockArticle} onChange={() => {}} onTagsChange={handleTagsChange} />
+      );
+
+      const addBtn = screen.getByRole("button", { name: "Add tag" });
+      fireEvent.click(addBtn);
+
+      const tagInput = screen.getByRole("textbox", { name: "New tag" });
+      fireEvent.change(tagInput, { target: { value: "draft" } });
+      fireEvent.keyDown(tagInput, { key: "Escape" });
+
+      // Input should be dismissed; no tag added
+      expect(screen.queryByRole("textbox", { name: "New tag" })).not.toBeInTheDocument();
+      expect(handleTagsChange).not.toHaveBeenCalled();
+    });
+
+    it("adds a tag when comma key is pressed", () => {
+      const handleTagsChange = jest.fn();
+      render(
+        <EditorPane article={mockArticle} onChange={() => {}} onTagsChange={handleTagsChange} />
+      );
+
+      const addBtn = screen.getByRole("button", { name: "Add tag" });
+      fireEvent.click(addBtn);
+
+      const tagInput = screen.getByRole("textbox", { name: "New tag" });
+      fireEvent.change(tagInput, { target: { value: "newtag" } });
+      fireEvent.keyDown(tagInput, { key: "," });
+
+      expect(handleTagsChange).toHaveBeenCalledWith(["markdown", "documentation", "newtag"]);
+    });
+  });
+
+  describe("Zen mode button", () => {
+    it("renders the expand button when onToggleZen is provided", () => {
+      render(<EditorPane article={mockArticle} onChange={() => {}} onToggleZen={() => {}} />);
+
+      expect(screen.getByTitle("Enter expand mode")).toBeInTheDocument();
+    });
+
+    it("shows exit title when zenMode is true", () => {
+      render(
+        <EditorPane
+          article={mockArticle}
+          onChange={() => {}}
+          onToggleZen={() => {}}
+          zenMode={true}
+        />
+      );
+
+      expect(screen.getByTitle("Exit expand mode")).toBeInTheDocument();
+    });
+
+    it("calls onToggleZen when the expand button is clicked", () => {
+      const handleZen = jest.fn();
+      render(<EditorPane article={mockArticle} onChange={() => {}} onToggleZen={handleZen} />);
+
+      fireEvent.click(screen.getByTitle("Enter expand mode"));
+      expect(handleZen).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not render expand button when onToggleZen is not provided", () => {
+      render(<EditorPane article={mockArticle} onChange={() => {}} />);
+
+      expect(screen.queryByTitle("Enter expand mode")).not.toBeInTheDocument();
+      expect(screen.queryByTitle("Exit expand mode")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("New article empty state", () => {
+    const newArticle: Article = {
+      slug: "__new__",
+      content: "",
+      meta: {
+        slug: "__new__",
+        title: "",
+        status: "draft",
+        tags: [],
+      },
+      versions: [],
+    };
+
+    it("shows empty-state prompt for __new__ article with no content", () => {
+      render(<EditorPane article={newArticle} onChange={() => {}} />);
+
+      expect(screen.getByText("Start a new article")).toBeInTheDocument();
+    });
+
+    it("does not show empty state for __new__ article that already has content", () => {
+      render(<EditorPane article={{ ...newArticle, content: "# Hello" }} onChange={() => {}} />);
+
+      expect(screen.queryByText("Start a new article")).not.toBeInTheDocument();
+    });
+
+    it("does not show empty state for a saved article with no content", () => {
+      render(<EditorPane article={{ ...mockArticle, content: "" }} onChange={() => {}} />);
+
+      expect(screen.queryByText("Start a new article")).not.toBeInTheDocument();
+    });
+
+    it("hides empty state when preview mode is toggled on for __new__", () => {
+      render(<EditorPane article={newArticle} onChange={() => {}} />);
+
+      const toggleButton = screen.getByTitle("Switch to preview");
+      fireEvent.click(toggleButton);
+
+      // Empty state relies on !previewMode — after toggling it should disappear
+      expect(screen.queryByText("Start a new article")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/ui/src/components/EditorPane.tsx
+++ b/ui/src/components/EditorPane.tsx
@@ -222,8 +222,48 @@ export function EditorPane({
         </div>
       </div>
 
+      {/* Empty state for new unsaved articles */}
+      {article.slug === "__new__" && article.content === "" && !previewMode && (
+        <div
+          className="flex-1 flex flex-col items-center justify-center gap-3 text-center"
+          style={{ background: "var(--bg-primary)", padding: 32 }}
+        >
+          <div
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: 12,
+              background: "var(--bg-tertiary)",
+              border: "1px solid var(--border)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 24,
+              color: "var(--text-secondary)",
+            }}
+          >
+            ✎
+          </div>
+          <h3 style={{ fontSize: 18, fontWeight: 500, color: "var(--text-primary)", margin: 0 }}>
+            Start a new article
+          </h3>
+          <p style={{ fontSize: 13, color: "var(--text-secondary)", margin: 0, maxWidth: 320 }}>
+            Give it a title above and start writing. Your article will be committed to GitHub when
+            you save.
+          </p>
+        </div>
+      )}
+
       {/* Monaco Editor */}
-      <div className="flex-1 overflow-hidden" style={{ display: previewMode ? "none" : "block" }}>
+      <div
+        className="flex-1 overflow-hidden"
+        style={{
+          display:
+            previewMode || (article.slug === "__new__" && article.content === "")
+              ? "none"
+              : "block",
+        }}
+      >
         <Suspense fallback={<EditorFallback />}>
           <Editor
             height="100%"

--- a/ui/src/components/SidePanel.test.tsx
+++ b/ui/src/components/SidePanel.test.tsx
@@ -116,10 +116,12 @@ describe("SidePanel", () => {
       expect(screen.queryByRole("button", { name: "Run Lint ↺" })).not.toBeInTheDocument();
     });
 
-    it("should show placeholder text before running lint", () => {
+    it("should show default lint metrics before running lint", () => {
       render(<SidePanel article={mockArticle} activeTab="lint" onTabChange={() => {}} />);
 
-      expect(screen.getByText(/Click "Run Lint" to analyze/i)).toBeInTheDocument();
+      expect(screen.getByText("Readability")).toBeInTheDocument();
+      expect(screen.getByText("B+")).toBeInTheDocument();
+      expect(screen.getByText("Avg sentence length")).toBeInTheDocument();
     });
 
     it("should have Run Lint button visible", () => {
@@ -307,31 +309,29 @@ describe("SidePanel", () => {
       expect(screen.getByText("B+")).toBeInTheDocument();
     });
 
-    it("should render empty state placeholder when lint tab loads without results", () => {
+    it("should render default lint metrics when lint tab loads", () => {
       render(<SidePanel article={mockArticle} activeTab="lint" onTabChange={() => {}} />);
 
-      expect(screen.getByText(/Click "Run Lint" to analyze/i)).toBeInTheDocument();
+      expect(screen.getByText("Readability")).toBeInTheDocument();
+      expect(screen.getByText("B+")).toBeInTheDocument();
     });
   });
 
   describe("Integration", () => {
-    it("should handle full user workflow: run lint and view results", () => {
+    it("should handle full user workflow: default metrics shown, run lint refreshes results", () => {
       render(<SidePanel article={mockArticle} activeTab="lint" onTabChange={() => {}} />);
 
-      // Start with placeholder
-      expect(screen.getByText(/Click "Run Lint" to analyze/i)).toBeInTheDocument();
+      // Default metrics visible immediately
+      expect(screen.getByText("Readability")).toBeInTheDocument();
+      expect(screen.getByText("B+")).toBeInTheDocument();
+      expect(screen.getByText("Avg sentence length")).toBeInTheDocument();
+      expect(screen.getByText(/Avoid "very"/i)).toBeInTheDocument();
 
-      // Run lint
+      // Run lint refreshes (same values in mock)
       const runLintButton = screen.getByRole("button", { name: "Run Lint ↺" });
       fireEvent.click(runLintButton);
 
-      // See results
-      expect(screen.getByText("Readability")).toBeInTheDocument();
       expect(screen.getByText("B+")).toBeInTheDocument();
-      expect(screen.getByText(/Avoid "very"/i)).toBeInTheDocument();
-
-      // Placeholder should be gone
-      expect(screen.queryByText(/Click "Run Lint" to analyze/i)).not.toBeInTheDocument();
     });
 
     it("should handle switching between tabs", () => {
@@ -524,6 +524,25 @@ describe("SidePanel", () => {
 
       expect(exportUtils.exportToPdf).not.toHaveBeenCalled();
       expect(exportUtils.exportToMarkdown).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Publish Tab - Export error handling", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should reset exporting state after PDF export error", async () => {
+      (exportUtils.exportToPdf as jest.Mock).mockRejectedValueOnce(new Error("PDF failed"));
+
+      render(<SidePanel article={mockArticle} activeTab="publish" onTabChange={() => {}} />);
+
+      const printButton = screen.getByRole("button", { name: /Print/ });
+      fireEvent.click(printButton);
+
+      // After the rejected promise settles, the button reverts to its normal label
+      await screen.findByRole("button", { name: /Print/ });
+      expect(screen.queryByRole("button", { name: /Printing.../ })).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/src/components/SidePanel.tsx
+++ b/ui/src/components/SidePanel.tsx
@@ -21,12 +21,25 @@ const PLATFORMS = [
 ];
 
 export function SidePanel({ article, activeTab, onTabChange }: Props) {
-  const [lintResults, setLintResults] = useState<null | {
+  const DEFAULT_LINT = {
+    readability: "B+",
+    style: 2,
+    grammar: 0,
+    avgSentenceLength: 17,
+    issues: [
+      { line: 5, message: 'Avoid "very" — it weakens your point' },
+      { line: 12, message: "Consider active voice here" },
+      { line: 23, message: "Long sentence (38 words) — consider splitting" },
+    ],
+  };
+
+  const [lintResults, setLintResults] = useState<{
     readability: string;
     style: number;
     grammar: number;
+    avgSentenceLength: number;
     issues: { line: number; message: string }[];
-  }>(null);
+  }>(DEFAULT_LINT);
 
   const [exporting, setExporting] = useState(false);
 
@@ -35,9 +48,11 @@ export function SidePanel({ article, activeTab, onTabChange }: Props) {
       readability: "B+",
       style: 2,
       grammar: 0,
+      avgSentenceLength: 17,
       issues: [
         { line: 5, message: 'Avoid "very" — it weakens your point' },
         { line: 12, message: "Consider active voice here" },
+        { line: 23, message: "Long sentence (38 words) — consider splitting" },
       ],
     });
   };
@@ -91,70 +106,64 @@ export function SidePanel({ article, activeTab, onTabChange }: Props) {
             Run Lint ↺
           </button>
 
-          {lintResults && (
-            <>
-              <div className="flex flex-col gap-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-xs" style={{ color: "var(--text-secondary)" }}>
-                    Readability
-                  </span>
-                  <span
-                    className="text-sm font-mono font-semibold"
-                    style={{ color: "var(--green)" }}
-                  >
-                    {lintResults.readability}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-xs" style={{ color: "var(--text-secondary)" }}>
-                    Style issues
-                  </span>
-                  <span
-                    className="text-sm font-mono"
-                    style={{ color: lintResults.style > 0 ? "var(--yellow)" : "var(--green)" }}
-                  >
-                    {lintResults.style}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-xs" style={{ color: "var(--text-secondary)" }}>
-                    Grammar errors
-                  </span>
-                  <span className="text-sm font-mono" style={{ color: "var(--green)" }}>
-                    {lintResults.grammar}
-                  </span>
-                </div>
-              </div>
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs" style={{ color: "var(--text-secondary)" }}>
+                Readability
+              </span>
+              <span className="text-sm font-mono font-semibold" style={{ color: "var(--green)" }}>
+                {lintResults.readability}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-xs" style={{ color: "var(--text-secondary)" }}>
+                Style issues
+              </span>
+              <span
+                className="text-sm font-mono"
+                style={{ color: lintResults.style > 0 ? "var(--yellow)" : "var(--green)" }}
+              >
+                {lintResults.style}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-xs" style={{ color: "var(--text-secondary)" }}>
+                Grammar errors
+              </span>
+              <span className="text-sm font-mono" style={{ color: "var(--green)" }}>
+                {lintResults.grammar}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-xs" style={{ color: "var(--text-secondary)" }}>
+                Avg sentence length
+              </span>
+              <span className="text-sm font-mono" style={{ color: "var(--text-primary)" }}>
+                {lintResults.avgSentenceLength} w
+              </span>
+            </div>
+          </div>
 
-              <div className="flex flex-col gap-2">
-                <h3
-                  className="text-xs font-semibold uppercase tracking-wider"
-                  style={{ color: "var(--text-secondary)" }}
-                >
-                  Issues
-                </h3>
-                {lintResults.issues.map((issue, i) => (
-                  <div
-                    key={i}
-                    className="p-2 rounded text-xs"
-                    style={{ background: "var(--bg-tertiary)" }}
-                  >
-                    <span className="font-mono" style={{ color: "var(--yellow)" }}>
-                      Line {issue.line}:
-                    </span>{" "}
-                    <span style={{ color: "var(--text-primary)" }}>{issue.message}</span>
-                  </div>
-                ))}
+          <div className="flex flex-col gap-2">
+            <h3
+              className="text-xs font-semibold uppercase tracking-wider"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              Issues
+            </h3>
+            {lintResults.issues.map((issue, i) => (
+              <div
+                key={i}
+                className="p-2 rounded text-xs"
+                style={{ background: "var(--bg-tertiary)" }}
+              >
+                <span className="font-mono" style={{ color: "var(--yellow)" }}>
+                  Line {issue.line}:
+                </span>{" "}
+                <span style={{ color: "var(--text-primary)" }}>{issue.message}</span>
               </div>
-            </>
-          )}
-
-          {!lintResults && (
-            <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
-              Click &quot;Run Lint&quot; to analyze your article for readability, style, and
-              grammar.
-            </p>
-          )}
+            ))}
+          </div>
         </div>
       )}
 

--- a/ui/src/components/TocTab.tsx
+++ b/ui/src/components/TocTab.tsx
@@ -42,7 +42,7 @@ function HeadingsList({ headings, onHeadingClick, depth = 0 }: HeadingsListProps
             style={{
               paddingLeft: `${depth * 16}px`,
               color: "var(--text-primary)",
-              fontWeight: "400",
+              fontWeight: depth === 0 ? "600" : "400",
               backgroundColor: "transparent",
             }}
           >


### PR DESCRIPTION
## Summary

Closes #156

- **Logo & landing**: V4 prompt-style logo (`$ inkwell▌` + `write · commit · publish` tagline) in the header; signed-out users now see a full-page `SignedOutLanding` component instead of the bare editor
- **Editor empty state**: `EditorPane` shows a centred ✎ icon + onboarding copy when the article slug is `__new__` and content is blank, hiding Monaco until the user starts typing
- **Lint tab defaults**: `SidePanel` lint tab displays metrics immediately on load (B+, style 2, grammar 0, avg sentence length 17 w) plus the issues list — no longer gated behind clicking "Run Lint"
- **TOC bold H1s**: depth-0 headings in `TocTab` are rendered with `fontWeight: "600"` to visually anchor the outline
- **Chat UX polish**: thread list capped at 96 px height with overflow clip, message bubbles capped at 85 % width, send button enlarged
- **Animations**: `@keyframes inkwell-blink` added to `globals.css` for the cursor blink in the new logo

## Test plan

- [x] 275 tests pass (`npm run test:coverage`)
- [x] Branch coverage 93.04 % (threshold 90 %)
- [x] Prettier, ESLint, TypeScript, and build all clean via quality gate
- [x] New tests cover: Escape/comma tag-input shortcuts, zen-mode button render/click, `__new__` empty-state branches, PDF export error recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)